### PR TITLE
Cleanup listeners to fix memory leak

### DIFF
--- a/lib/controllers/request-response.js
+++ b/lib/controllers/request-response.js
@@ -30,6 +30,10 @@ RequestResponseController.prototype.request = function(data, callback) {
 
   this.on('message', onmessage);
   
+  setTimeout(function(){
+   self.removeListener('message', onmessage);
+   },50000);
+
   data.requestId = requestId;
   this.send(data);
 };


### PR DESCRIPTION
Message listeners that don't receive any event for their requestId didn't ever get removed, triggering the Too Many Listeners warning.  
After a certain timeout (50 sec arbitrarily) we are not interested in the response message anymore, and remove the listener anyway.